### PR TITLE
Support PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 vendor/
 composer.lock
 phpunit.xml
+.phpunit.result.cache
+/.idea
+/.vscode
+build/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 
-php: 7.2
+php:
+    - 7.3
+    - 7.4
+    - 8.0
+    - nightly
 
 install:
     - composer update --prefer-stable --prefer-dist
 
 script:
-    - composer test-ci
+    - XDEBUG_MODE=coverage composer test-ci
 
 after_success:
     - wget https://scrutinizer-ci.com/ocular.phar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,19 @@
 ## 0.1.0
 
 First "release" of this library. 
+
+## 0.2.0
+
+Add support for empty responses.
+
+* If the address or coordinates of the request don't match, return an empty response. If they do, return the details provided during the provider's instantiation.
+
+## 0.2.1
+
+AdminLevels are objects rather than arrays
+
+## 0.3.0
+
+Support for PHP 8.
+
+* Update dependencies

--- a/Tests/IntegrationTest.php
+++ b/Tests/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends ProviderIntegrationTest
      * @var array with functionName => reason
      */
     protected $skippedTests = [
-        'testExceptions' => 'Throwng exceptions is not supported by this provider',
+        'testExceptions' => 'Throwing exceptions is not supported by this provider',
     ];
 
     protected $testAddress = true;

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3 || ^8.0",
         "geocoder-php/common-http": "^4.1",
         "willdurand/geocoder": "^4.0"
     },
@@ -21,9 +21,9 @@
     },
     "require-dev": {
         "geocoder-php/provider-integration-tests": "^1.0",
-        "php-http/curl-client": "^1.7",
+        "php-http/curl-client": "^2.2.0",
         "php-http/message": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^9.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
->
+         bootstrap="vendor/autoload.php">
+    <coverage>
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </coverage>
     <php>
-        <server name="USE_CACHED_RESPONSES" value="true" />
+        <server name="USE_CACHED_RESPONSES" value="true"/>
     </php>
-
     <testsuites>
         <testsuite name="Geocoder Test Suite">
             <directory>./Tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./Tests</directory>
-                <directory>./vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
Hello!

I am issuing this Pull Request to make GeocoderMockProvider even more awesome!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/danhunsaker/.github/blob/main/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant `CHANGELOG`

Small description of change:

Upgrades the package to support PHP 8 (which drops support for 7.2, even though no code changes are present).